### PR TITLE
No need for unused StringDescriptor

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
@@ -11,7 +11,6 @@ import io.ktor.client.features.json.serializer.KotlinxSerializer
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
 import kotlinx.serialization.*
-import kotlinx.serialization.internal.StringDescriptor
 
 {{#operations}}
 @ExperimentalStdlibApi


### PR DESCRIPTION
StringDescriptor is removed in coroutines 1.4.x, so if we don't remove this, the build will fail.
It was unused anyways.