### PR TITLE
External and internal should be reserved keywords

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -124,7 +124,9 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
                 "val",
                 "var",
                 "when",
-                "while"
+                "while",
+                "internal",
+                "external"
         ));
 
         defaultIncludes = new HashSet<String>(Arrays.asList(

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/KotlinClientCodegen.java
@@ -115,7 +115,6 @@ public class KotlinClientCodegen extends AbstractKotlinCodegen {
      */
     public KotlinClientCodegen() {
         super();
-
         /*
          * OAuth flows supported _only_ by client explicitly setting bearer token. The "flows" are not supported.
          */


### PR DESCRIPTION
The new settings API contains these keywords, turns out they are reserved by Kotlin.