### PR TITLE
Fix list serializer not working

### DIFF
--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/api.mustache
@@ -8,6 +8,11 @@ import {{packageName}}.infrastructure.*
 import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.features.json.serializer.KotlinxSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
 import kotlinx.serialization.*

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_request_list.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_request_list.mustache
@@ -2,8 +2,8 @@
     private class {{operationIdCamelCase}}Request(val value: List<{{#bodyParam}}{{baseType}}{{/bodyParam}}>) {
         @Serializer({{operationIdCamelCase}}Request::class)
         {{#nonPublicApi}}internal {{/nonPublicApi}}companion object : KSerializer<{{operationIdCamelCase}}Request> {
-            private val serializer: KSerializer<List<{{#bodyParam}}{{baseType}}{{/bodyParam}}>> = {{#bodyParam}}{{baseType}}{{/bodyParam}}.serializer().list
-                override val descriptor = StringDescriptor.withName("{{operationIdCamelCase}}Request")
+            private val serializer: KSerializer<List<{{#bodyParam}}{{baseType}}{{/bodyParam}}>> = ListSerializer({{#bodyParam}}{{baseType}}{{/bodyParam}}.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("{{operationIdCamelCase}}Request", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: {{operationIdCamelCase}}Request) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = {{operationIdCamelCase}}Request(serializer.deserialize(decoder))
         }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_request_map.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_request_map.mustache
@@ -3,7 +3,7 @@
         @Serializer({{operationIdCamelCase}}Request::class)
         {{#nonPublicApi}}internal {{/nonPublicApi}}companion object : KSerializer<{{operationIdCamelCase}}Request> {
             private val serializer: KSerializer<Map<kotlin.String, {{#bodyParam}}{{baseType}}{{/bodyParam}}>> = (kotlin.String.serializer() to {{#bodyParam}}{{baseType}}{{/bodyParam}}.serializer()).map
-                override val descriptor = StringDescriptor.withName("{{operationIdCamelCase}}Request")
+                override val descriptor = PrimitiveSerialDescriptor("{{operationIdCamelCase}}Request", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: {{operationIdCamelCase}}Request) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = {{operationIdCamelCase}}Request(serializer.deserialize(decoder))
         }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_response_list.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_response_list.mustache
@@ -2,8 +2,8 @@
     private class {{operationIdCamelCase}}Response(val value: List<{{returnBaseType}}>) {
         @Serializer({{operationIdCamelCase}}Response::class)
         {{#nonPublicApi}}internal {{/nonPublicApi}}companion object : KSerializer<{{operationIdCamelCase}}Response> {
-            private val serializer: KSerializer<List<{{returnBaseType}}>> = {{returnBaseType}}.serializer().list
-                override val descriptor = StringDescriptor.withName("{{operationIdCamelCase}}Response")
+            private val serializer: KSerializer<List<{{returnBaseType}}>> = ListSerializer({{returnBaseType}}.serializer())
+                override val descriptor = PrimitiveSerialDescriptor("{{operationIdCamelCase}}Response", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: {{operationIdCamelCase}}Response) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = {{operationIdCamelCase}}Response(serializer.deserialize(decoder))
         }

--- a/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_response_map.mustache
+++ b/modules/openapi-generator/src/main/resources/kotlin-client/libraries/multiplatform/serial_wrapper_response_map.mustache
@@ -3,7 +3,7 @@
         @Serializer({{operationIdCamelCase}}Response::class)
         {{#nonPublicApi}}internal {{/nonPublicApi}}companion object : KSerializer<{{operationIdCamelCase}}Response> {
             private val serializer: KSerializer<Map<kotlin.String, {{returnBaseType}}>> = (kotlin.String.serializer() to {{returnBaseType}}.serializer()).map
-                override val descriptor = StringDescriptor.withName("{{operationIdCamelCase}}Response")
+                override val descriptor = PrimitiveSerialDescriptor("{{operationIdCamelCase}}Response", PrimitiveKind.STRING)
                 override fun serialize(encoder: Encoder, obj: {{operationIdCamelCase}}Response) = serializer.serialize(encoder, obj.value)
                 override fun deserialize(decoder: Decoder) = {{operationIdCamelCase}}Response(serializer.deserialize(decoder))
         }


### PR DESCRIPTION
The list serializer used an old API which does not exist anymore in KotlinX serialization.
Also the descriptor was also wrong, and there were missing imports.